### PR TITLE
txt_without_tc output option

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ import whisper_api
 import output
 import timecode
 
-app_version = 'v 1.2.0'
+app_version = 'v 1.3.0'
 
 def browse_files():
     filename = customtkinter.filedialog.askopenfilename(initialdir="/", title="Select a file")

--- a/output.py
+++ b/output.py
@@ -3,7 +3,7 @@ import datetime as dt
 import timecode
 import csv
 
-output_options = ['', 'txt', 'csv', 'srt']
+output_options = ['', 'txt', 'txt without TC','csv', 'srt']
 
 def write_txt(audio_file, model_name, language, translation, result, start_time):
     now = dt.datetime.now()
@@ -14,6 +14,17 @@ def write_txt(audio_file, model_name, language, translation, result, start_time)
     output_file.write(f"Transcription performed on {now.strftime('%Y-%m-%d %H:%M:%S')}.\nLanguage: {language}\nModel: {model_name}\nTranslation: {translation}\n\n")
     for segment in result['segments']:
         output_file.write(f"[{timecode.time_to_TC(segment['start'] + start_time, 25)} - {timecode.time_to_TC(segment['end'] + start_time, 25)}]   > ")
+        output_file.write(f"{segment['text']}\n")
+    output_file.close()
+
+def write_txt_without_tc(audio_file, model_name, language, translation, result):
+    now = dt.datetime.now()
+    audio_filename = os.path.basename(audio_file)
+    dir_name = os.path.dirname(audio_file)
+    
+    output_file = open(os.path.join(dir_name, f"{now.strftime('%Y%m%d-%H%M%S')}_{audio_filename}_transcription.txt"), 'wt')
+    output_file.write(f"Transcription performed on {now.strftime('%Y-%m-%d %H:%M:%S')}.\nLanguage: {language}\nModel: {model_name}\nTranslation: {translation}\n\n")
+    for segment in result['segments']:
         output_file.write(f"{segment['text']}\n")
     output_file.close()
 

--- a/whisper_api.py
+++ b/whisper_api.py
@@ -32,6 +32,8 @@ def start_whisper(audio_file, model_name, language, translation, output_mode, st
 
     if output_mode == 'txt':
         output.write_txt(audio_file, model_name, language, translation, result, start_time)
+    if output_mode == 'txt without TC':
+        output.write_txt_without_tc(audio_file, model_name, language, translation, result)
     elif output_mode == 'csv':
         output.write_csv(audio_file, model_name, language, translation, result, start_time)
     elif output_mode == 'srt':


### PR DESCRIPTION
Added a txt_without_tc output option. Faster than adding a switch. A switch would only be useful for txt anyway, not csv or srt.